### PR TITLE
use softplus activation for sigma

### DIFF
--- a/models/nerf.py
+++ b/models/nerf.py
@@ -72,7 +72,7 @@ class SimpleNeRF(nn.Module):
         """
         out = self.net(x)
         rgb = torch.sigmoid(out[..., :-1])
-        sigma = F.relu(out[..., -1])
+        sigma = F.softplus(out[..., -1])
         return rgb, sigma
 
 


### PR DESCRIPTION
ReLU activation for sigma can cause optimization to fail. Using Softplus should solve this issue. See [mip-NeRF](https://arxiv.org/abs/2103.13415) section E.2 for a discussion.